### PR TITLE
Select only available sensors

### DIFF
--- a/HiaacLib/app/src/main/java/br/org/eldorado/hiaac/datacollector/EldoradoLabelOptionsActivity.java
+++ b/HiaacLib/app/src/main/java/br/org/eldorado/hiaac/datacollector/EldoradoLabelOptionsActivity.java
@@ -287,10 +287,11 @@ public class EldoradoLabelOptionsActivity extends AppCompatActivity {
 
     private void checkAllSensors() {
         for (SensorFrequencyViewAdapter.SelectedSensorFrequency sensor : mSelectedSensors) {
-            sensor.setSelected(true);
-            sensor.setFrequency(40);
+            if(mSensorFrequencyViewAdapter.checkSensorAvailability(sensor.getSensor())) {
+                sensor.setSelected(true);
+                sensor.setFrequency(40);
+            }
         }
-
     }
 
     @Override


### PR DESCRIPTION
When creating a new configuration, only select the avaible device's sensors